### PR TITLE
feat: update default session length from 18 to 12 hours

### DIFF
--- a/apps/cloud/app/routes/session._index.tsx
+++ b/apps/cloud/app/routes/session._index.tsx
@@ -19,7 +19,7 @@ import { ActionFunctionArgs, json } from '@vercel/remix'
 import { ArrowLeft } from 'lucide-react'
 import { useState } from 'react'
 
-const LIVE_SESSION_LENGTH = 1000 * 60 * 60 * 18
+const LIVE_SESSION_LENGTH = 1000 * 60 * 60 * 12
 
 export const loader = async () => {
     const setlists = await getSetlists()


### PR DESCRIPTION
## Summary
- Updated default session length from 18 to 12 hours

## Changes
- Modified session timeout configuration to use 12 hours instead of 18 hours
- This provides a more reasonable default session duration for users

## Test plan
- [ ] Verify session expires after 12 hours
- [ ] Confirm existing sessions are not affected
- [ ] Test session renewal functionality